### PR TITLE
Inline code needed for Outlook 2007, 2010 & 2013

### DIFF
--- a/email.html
+++ b/email.html
@@ -195,7 +195,7 @@ ul li, ol li {
 						<p>All the information you need is on GitHub.</p>
 						<table>
 							<tr>
-								<td class="padding">
+								<td class="padding" style="padding: 10px 0;">
 									<p><a href="https://github.com/leemunroe/html-email-template" class="btn-primary">View the source and instructions on GitHub</a></p>
 								</td>
 							</tr>


### PR DESCRIPTION
Outlook 2007, 2010 & 2013 don't render the button correctly without the inline styling.
