### PR TITLE
Lower case css property

### DIFF
--- a/email.html
+++ b/email.html
@@ -153,7 +153,7 @@ ol li {
 .container {
   clear: both !important;
   display: block !important;
-  Margin: 0 auto !important;
+  margin: 0 auto !important;
   max-width: 600px !important;
 }
 


### PR DESCRIPTION
My IDE had "Margin" underlined as an "unknown css property".

I'm sure browsers don't care though.