### PR TITLE
Fix "margin" capitalization

### DIFF
--- a/email.html
+++ b/email.html
@@ -45,7 +45,7 @@
       /* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
       .container {
         display: block;
-        Margin: 0 auto !important;
+        margin: 0 auto !important;
         /* makes it centered */
         max-width: 580px;
         padding: 10px;
@@ -56,7 +56,7 @@
       .content {
         box-sizing: border-box;
         display: block;
-        Margin: 0 auto;
+        margin: 0 auto;
         max-width: 580px;
         padding: 10px; }
 
@@ -97,7 +97,7 @@
         font-weight: 400;
         line-height: 1.4;
         margin: 0;
-        Margin-bottom: 30px; }
+        margin-bottom: 30px; }
 
       h1 {
         font-size: 35px;
@@ -112,7 +112,7 @@
         font-size: 14px;
         font-weight: normal;
         margin: 0;
-        Margin-bottom: 15px; }
+        margin-bottom: 15px; }
         p li,
         ul li,
         ol li {
@@ -205,7 +205,7 @@
       hr {
         border: 0;
         border-bottom: 1px solid #f6f6f6;
-        Margin: 20px 0; }
+        margin: 20px 0; }
 
       /* -------------------------------------
           RESPONSIVE AND MOBILE FRIENDLY STYLES


### PR DESCRIPTION
Not sure if this is intentional or not, but `margin` is `Margin` sometimes in the CSS.