### PR TITLE
Correcting .container width in outlook 2007, 2010 and 2013

### DIFF
--- a/email.html
+++ b/email.html
@@ -49,7 +49,6 @@
         /* makes it centered */
         max-width: 580px;
         padding: 10px;
-        width: auto !important;
         width: 580px; }
 
       /* This should also be a block element, so that it will fill 100% of the .container */


### PR DESCRIPTION
The .container was appearing narrow when I tested. This CSS rule does
not appear in the email-inlined version.  Removing it from email.html
corrects the width issues in Outlook 07, 10 and 13.  Tested via litmus
and can see no detrimental effect from the removal of this rule.
![after](https://cloud.githubusercontent.com/assets/7091410/20850350/8fcbe118-b8d2-11e6-8d6a-483b95742fab.png)
![before](https://cloud.githubusercontent.com/assets/7091410/20850349/8fc7fb34-b8d2-11e6-86ab-9065ae193a01.png)


