### PR TITLE
tables should not convey semantic roles

### DIFF
--- a/email.html
+++ b/email.html
@@ -275,7 +275,7 @@
     </style>
   </head>
   <body class="">
-    <table border="0" cellpadding="0" cellspacing="0" class="body">
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
       <tr>
         <td>&nbsp;</td>
         <td class="container">
@@ -283,21 +283,21 @@
 
             <!-- START CENTERED WHITE CONTAINER -->
             <span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>
-            <table class="main">
+            <table role="presentation" class="main">
 
               <!-- START MAIN CONTENT AREA -->
               <tr>
                 <td class="wrapper">
-                  <table border="0" cellpadding="0" cellspacing="0">
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                     <tr>
                       <td>
                         <p>Hi there,</p>
                         <p>Sometimes you just want to send a simple HTML email with a simple design and clear call to action. This is it.</p>
-                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>
                               <td align="left">
-                                <table border="0" cellpadding="0" cellspacing="0">
+                                <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                   <tbody>
                                     <tr>
                                       <td> <a href="http://htmlemail.io" target="_blank">Call To Action</a> </td>
@@ -321,7 +321,7 @@
 
             <!-- START FOOTER -->
             <div class="footer">
-              <table border="0" cellpadding="0" cellspacing="0">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
                     <span class="apple-link">Company Inc, 3 Abbey Road, San Francisco CA 94102</span>


### PR DESCRIPTION
Overriding the implicit role of `table`, as requested in: https://github.com/leemunroe/responsive-html-email-template/issues/67

Optionally, the newer synonym `none` could be used in conjunction or instead of `presentation`, just consider that some screen-readers may only recognize `presentation`. 

> Until implementations include sufficient support for role="none", web authors are advised to use the presentation role alone role="presentation" or redundantly as a fallback to the none role role="none presentation".

_- https://w3c.github.io/aria/#none_