### PR TITLE
Don't show whitespace before the preheader text

### DIFF
--- a/email.html
+++ b/email.html
@@ -325,6 +325,7 @@
     </style>
   </head>
   <body class="">
+    <span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
       <tr>
         <td>&nbsp;</td>
@@ -332,7 +333,6 @@
           <div class="content">
 
             <!-- START CENTERED WHITE CONTAINER -->
-            <span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>
             <table role="presentation" class="main">
 
               <!-- START MAIN CONTENT AREA -->


### PR DESCRIPTION
Don't show whitespace before the preheader text in Outlook App for Windows 10, possibly caused by the `&nbsp;`.

This is an image that compares two preheader texts:

![image](https://user-images.githubusercontent.com/11742754/53104601-f0ba7f80-352f-11e9-9e01-21f39a2a76b0.png)

As you can see, the second email's preheader text shows trailing whitespace, while the first one doesn't.

Please do notice I added an image *before* and *outside* the white box of the template, but I think the white space probably comes from the `&nbsp;`s